### PR TITLE
Pipes meet RSpec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.ruby-version
+.ruby-gemset
 *.gem
 *.rbc
 .bundle

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rspec', '~> 3.1'
+  gem 'rspec'
 end

--- a/lib/codequest_pipes/context.rb
+++ b/lib/codequest_pipes/context.rb
@@ -65,5 +65,15 @@ module Pipes
     def failure?
       !success?
     end
+
+    # Printable string representation of the context
+    #
+    # @return [String]
+    def inspect
+      keys = methods - Object.methods - Pipes::Context.instance_methods
+      fields = keys.map { |key| "#{key}=#{public_send(key).inspect}" }
+      fields << "@error=#{@error.inspect}"
+      "#<Pipes::Context:0x007ffd5d675630 #{fields.join(', ')}>"
+    end
   end # class Context
 end # module Pipes

--- a/lib/codequest_pipes/context.rb
+++ b/lib/codequest_pipes/context.rb
@@ -67,13 +67,15 @@ module Pipes
     end
 
     # Printable string representation of the context
+    # object_id_hex explained: http://stackoverflow.com/a/2818916/3526316
     #
     # @return [String]
     def inspect
       keys = methods - Object.methods - Pipes::Context.instance_methods
       fields = keys.map { |key| "#{key}=#{public_send(key).inspect}" }
       fields << "@error=#{@error.inspect}"
-      "#<Pipes::Context:0x007ffd5d675630 #{fields.join(', ')}>"
+      object_id_hex = '%x' % (object_id << 1)
+      "#<Pipes::Context:0x00#{object_id_hex} #{fields.join(', ')}>"
     end
   end # class Context
 end # module Pipes

--- a/lib/codequest_pipes/rspec.rb
+++ b/lib/codequest_pipes/rspec.rb
@@ -1,0 +1,16 @@
+RSpec::Matchers.define :pipe_context do |expected_hash|
+  def matches_or_equals?(actual, expected)
+    return expected.matches?(actual) if expected.respond_to?(:matches?)
+    expected == actual
+  end
+
+  match do |ctx|
+    return false unless ctx.is_a?(Pipes::Context)
+    expected_hash.all? do |key, val|
+      next false unless ctx.respond_to?(key)
+      matches_or_equals?(ctx.public_send(key), val)
+    end
+  end
+
+  diffable
+end

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -14,11 +14,11 @@ describe Pipes::Context do
     end
   end # describe '#add'
 
-  describe '#to_s' do
+  describe '#inspect' do
     it 'lists all fields' do
       subject.add(bacon: 'yum', raisins: 'bleh')
       expect(subject.inspect)
         .to match(/bacon=\"yum\", raisins=\"bleh\", @error=nil/)
     end
-  end # describe '#to_s'
+  end # describe '#inspect'
 end # describe Pipes::Context

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -20,5 +20,11 @@ describe Pipes::Context do
       expect(subject.inspect)
         .to match(/bacon=\"yum\", raisins=\"bleh\", @error=nil/)
     end
+
+    it 'lists nested contexts' do
+      subject.add(nested: Pipes::Context.new(foo: 'bar'))
+      expect(subject.inspect)
+        .to match(/nested=#<Pipes::Context:0x\w+ foo="bar", @error=nil>,/)
+    end
   end # describe '#inspect'
 end # describe Pipes::Context

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -1,18 +1,24 @@
 require 'spec_helper'
 
 describe Pipes::Context do
-  let(:ctx) { Pipes::Context.new }
-
   describe '#add' do
     it 'allows adding new fields' do
-      ctx.add(key: 'val')
-      expect(ctx.key).to eq('val')
+      subject.add(key: 'val')
+      expect(subject.key).to eq('val')
     end
 
     it 'does not allow rewriting existing fields' do
-      ctx.add(key: 'val')
-      expect { ctx.add(key: 'other_val') }
+      subject.add(key: 'val')
+      expect { subject.add(key: 'other_val') }
         .to raise_error(Pipes::Context::Override)
     end
-  end
-end # describe Context
+  end # describe '#add'
+
+  describe '#to_s' do
+    it 'lists all fields' do
+      subject.add(bacon: 'yum', raisins: 'bleh')
+      expect(subject.inspect)
+        .to match(/bacon=\"yum\", raisins=\"bleh\", @error=nil/)
+    end
+  end # describe '#to_s'
+end # describe Pipes::Context

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'rspec/matchers/fail_matchers'
+require 'codequest_pipes/rspec'
+
+RSpec.configure do |config|
+  config.include RSpec::Matchers::FailMatchers
+end
+
+describe 'expect(...).to match(pipe_context(expected))' do
+  let(:ctx) { Pipes::Context.new(foo: 'foo', bar: {}, baz: 1) }
+  let(:expected) { nil }
+
+  shared_examples_for 'fails_with_message' do |message|
+    it 'fails' do
+      expected_message =
+        message || /expected #<Pipes::Context:.+ @error=nil> to match/
+      expect { expect(ctx).to match(pipe_context(expected)) }
+        .to fail_with(expected_message)
+    end
+  end # shared_examples_for 'fails'
+
+  context 'when any key is missing' do
+    let(:expected) { {foo: 'foo', bacon: {}} }
+    it_behaves_like 'fails_with_message'
+  end # context 'when any key is missing'
+
+  context 'when actual is not Pipes::Context' do
+    let(:ctx) { 'bacon' }
+
+    it_behaves_like 'fails_with_message', /expected "bacon" to match/
+  end # context 'when expected is not Pipes::Context'
+
+  context 'when any key matcher fails' do
+    let(:expected) { {foo: 'foo', bar: {}, baz: 'bacon'} }
+
+    it_behaves_like 'fails_with_message'
+  end # context 'when any key matcher fails'
+
+  context 'when any value not equal' do
+    let(:expected) { {foo: 'foo', bar: {}, baz: 2} }
+
+    it_behaves_like 'fails_with_message'
+  end
+
+  context 'when all keys match' do
+    let(:expected) { {foo: 'foo', bar: {}, baz: 1} }
+    it 'succeeds' do
+      expect(ctx).to match(pipe_context(expected))
+    end
+  end # context 'when all keys match'
+end # describe 'pipe_context'


### PR DESCRIPTION
✅ better `#inspect` for contexts
✅ `codequest_pipes/rspec` available with `pipe_context` matcher. Example usage: https://github.com/thecodebeat/frontend/blob/master/spec/services/subscriptions/cancellation_handler_spec.rb