### PR TITLE
Add ErrorCollector object to Pipes::Context

### DIFF
--- a/codequest_pipes.gemspec
+++ b/codequest_pipes.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name    = 'codequest_pipes'
-  spec.version = '0.3.1.1'
+  spec.version = '0.3.2'
 
   spec.author      = 'codequest'
   spec.email       = 'hello@codequest.com'

--- a/lib/codequest_pipes/context.rb
+++ b/lib/codequest_pipes/context.rb
@@ -32,22 +32,19 @@ module Pipes
       end
     end
 
-    # Quietly fail the pipe.
-    def halt
-      @halted = true
-    end
-
-    # Check if the Context is halted.
+    # Quietly fail the pipe. The error will be passed to the error_collector
+    # and stored in the :base errors collection.
     #
-    # @return [Boolean] halt status.
-    def halted?
-      @halted
+    ## @param error [String]
+    def halt(error = 'Execution stopped')
+      add_errors(base: error)
     end
 
     # Explicitly fail the pipe.
     #
     # @raise [ExecutionTerminated]
-    def terminate
+    def terminate(error)
+      halt(error)
       fail ExecutionTerminated
     end
 
@@ -83,6 +80,15 @@ module Pipes
     # @return [Hash]
     def errors
       error_collector.errors
+    end
+
+    # This method is added to maintain backwards compatibility - previous
+    # versions implemented a single @error instance variable of String for error
+    # storage.
+    #
+    # @return [String]
+    def error
+      errors[:base]&.first
     end
 
     # Add errors to ErrorCollector object.

--- a/lib/codequest_pipes/context/error_collector.rb
+++ b/lib/codequest_pipes/context/error_collector.rb
@@ -1,0 +1,20 @@
+module Pipes
+  class Context
+    # ErrorCollector is Context's companion object for storing non-critical
+    # errors.
+    class ErrorCollector
+      attr_reader :errors
+
+      def initialize
+        @errors = {}
+      end
+
+      def add(errors_hash)
+        errors_hash.map do |key, errors|
+          @errors[key] ||= []
+          @errors[key] = @errors[key] | Array(errors)
+        end
+      end
+    end # class ErrorColletor
+  end # class Context
+end # module Pipes

--- a/lib/codequest_pipes/pipe.rb
+++ b/lib/codequest_pipes/pipe.rb
@@ -20,7 +20,7 @@ module Pipes
     end
 
     def self.call(ctx)
-      return ctx if ctx.halted?
+      return ctx if ctx.errors.any?
       _validate_ctx(_required_context_elements, ctx)
       new(ctx).call
       _validate_ctx(_provided_context_elements, ctx)

--- a/lib/codequest_pipes/pipe.rb
+++ b/lib/codequest_pipes/pipe.rb
@@ -20,7 +20,7 @@ module Pipes
     end
 
     def self.call(ctx)
-      return ctx if ctx.error
+      return ctx if ctx.halted?
       _validate_ctx(_required_context_elements, ctx)
       new(ctx).call
       _validate_ctx(_provided_context_elements, ctx)

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -41,4 +41,11 @@ describe Pipes::Context do
       )
     end
   end # describe '#add_errors'
+
+  describe '#halt' do
+    it 'adds error to error collector :base' do
+      subject.halt('Some error')
+      expect(subject.error).to eq('Some error')
+    end
+  end # describe '#halt'
 end # describe Pipes::Context

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -18,13 +18,27 @@ describe Pipes::Context do
     it 'lists all fields' do
       subject.add(bacon: 'yum', raisins: 'bleh')
       expect(subject.inspect)
-        .to match(/bacon=\"yum\", raisins=\"bleh\", @error=nil/)
+        .to match(/bacon=\"yum\", raisins=\"bleh\", @errors=nil/)
     end
 
     it 'lists nested contexts' do
       subject.add(nested: Pipes::Context.new(foo: 'bar'))
       expect(subject.inspect)
-        .to match(/nested=#<Pipes::Context:0x\w+ foo="bar", @error=nil>,/)
+        .to match(/nested=#<Pipes::Context:0x\w+ foo="bar", @errors=nil>,/)
     end
   end # describe '#inspect'
+
+  describe '#add_errors' do
+    it 'adds error to error_collector' do
+      subject.add_errors(base: 'Error message')
+      subject.add_errors(
+        base: ['Another error message'],
+        user: 'User error message'
+      )
+      expect(subject.errors).to eq(
+        base: ['Error message', 'Another error message'],
+        user: ['User error message']
+      )
+    end
+  end # describe '#add_errors'
 end # describe Pipes::Context

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -13,7 +13,7 @@ describe 'expect(...).to match(pipe_context(expected))' do
   shared_examples_for 'fails_with_message' do |message|
     it 'fails' do
       expected_message =
-        message || /expected #<Pipes::Context:.+ @error=nil> to match/
+        message || /expected #<Pipes::Context:.+ @errors=nil> to match/
       expect { expect(ctx).to match(pipe_context(expected)) }
         .to fail_with(expected_message)
     end


### PR DESCRIPTION
Add an error collector to Context to enable storing multiple errors within one pipe before failing it. Co-authored by @pjanek